### PR TITLE
Playbook and documentation enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ For a detailed explanation and documentation on how MQ-Ansible works, click [her
 
 ## Requirements
 
-- `ansible` and `ansible-lint` are required on your local machine to run playbooks implementing this collection.
+- `ansible`, `passlib` and `ansible-lint` are required on your local machine to run playbooks implementing this collection.
 - An Ubuntu target machine is required to run MQ.
+
+ ##### *Ansible* installation ([Installation guide](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html))
 
 ## Playbooks and Roles for IBM MQ installation
 
@@ -86,7 +88,7 @@ mq-setup.yml - this playbook sets up IBM MQ using the 'mqm' user
 
 Before running the playbook and implementing our modules and roles for IBM MQ:
 
-1. Check if you have an *ssh* key pair in order to access the target machines via Ansible. Go to the `~/.ssh` directory in your machine and look for the `id_rsa` and `id_rsa.pub` files.
+1. Check if you have an *ssh* key pair in order to access the target machines via SSH. Go to the `~/.ssh` directory in your machine and look for the public and private key files e.g. `id_rsa` and `id_rsa.pub`.
 
     ```shell
      cd ~/.ssh
@@ -111,15 +113,16 @@ Before running the playbook and implementing our modules and roles for IBM MQ:
     ```
     This should connect to your target machine without asking for a password.
     
-5. Go to the `ansible_collections/ibm/ibmmq/` directory.
+5. On your local machine clone this repository. 
+
+6. Go to the `ansible_collections/ibm/ibmmq/` directory.
 
     ```shell
-     cd ..
-     cd ansible_collections/ibm/ibmmq/
+     cd mq-ansible/ansible_collections/ibm/ibmmq/
     ```
 
 
-6. Create a file `inventory.ini` inside the directory with the following content:
+7. Create a file `inventory.ini` inside the directory with the following content:
   
     ```ini
     
@@ -140,7 +143,7 @@ The sample playbook [`ibmmq.yml`](ansible_collections/ibm/ibmmq/ibmmq.yml) insta
 
 1. Before running the playbook, ensure that you have added the following directory path to the ANSIBLE_LIBRARY environment variable.
 
-    ##### *NOTE*: change `<PATH-TO>` to your local directory path:
+    ##### *Note*: change `<PATH-TO>` to your local directory path:
 
     - On Mac:
 
@@ -156,9 +159,9 @@ The sample playbook [`ibmmq.yml`](ansible_collections/ibm/ibmmq/ibmmq.yml) insta
 
 2. Run the following command to execute the tasks within the playbook:
       ```shell
-       ansible-playbook ./ibmmq.yml -i inventory.ini [-K]
+       ansible-playbook ./ibmmq.yml -i inventory.ini
       ```
-      - ##### *Note*: the optional `-K` will prompt the user to enter the sudo password for [YOUR_SSH_USER] on the target machine, you can omit if you have setup SSH keys
+      - ##### *Note*: you can optionally add `-K` (uppercase) to the command, this will prompt the user to enter the sudo password for [YOUR_SSH_USER] on the target machine, you can omit if you have setup SSH keys
 
 3. The playbook should return the result of `dspmq` with the queue manager created listed. Log into your target machine and check it manually:
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ mq-setup.yml - this playbook sets up IBM MQ using the 'mqm' user
 
 # Run our sample playbook
 
-##### *Note*: *Ansible* must be installed on the local machine. ([Installation guide](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html))
+##### *Note*: *Ansible* must be installed on the local machine ([Installation guide](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html))
 
 Before running the playbook and implementing our modules and roles for IBM MQ:
 
@@ -128,11 +128,11 @@ Before running the playbook and implementing our modules and roles for IBM MQ:
     YOUR_HOST_ALIAS ansible_host=YOUR_HOSTNAME ansible_ssh_user=YOUR_SSH_USER
 
     ```
-   ##### *Note*: You can specify one or more hosts.
+   ##### *Note*: you can specify one or more hosts
    - Change `YOUR_HOST_ALIAS` to an alias name that you wish to use e.g. `mq-host-1` , you can omit aliases if you prefer
    - Change `YOUR_HOSTNAME` to your server/hostname, e.g. `myserver-1.fyre.com`
    - Change `YOUR_SSH_USER` to your target machine's SSH user
-   ##### *Note*: the user on the target machine MUST have `root` or `sudo` privileges.
+   ##### *Note*: the user on the target machine MUST have `root` or `sudo` privileges
 
 ### ibmmq.yml
 
@@ -158,7 +158,7 @@ The sample playbook [`ibmmq.yml`](ansible_collections/ibm/ibmmq/ibmmq.yml) insta
       ```shell
        ansible-playbook ./ibmmq.yml -i inventory.ini [-K]
       ```
-      - ##### *Note*: The optional `-K` will prompt the user to enter the sudo password for [YOUR_SSH_USER] on the target machine, you can omit if you have setup SSH keys.
+      - ##### *Note*: the optional `-K` will prompt the user to enter the sudo password for [YOUR_SSH_USER] on the target machine, you can omit if you have setup SSH keys
 
 3. The playbook should return the result of `dspmq` with the queue manager created listed. Log into your target machine and check it manually:
 
@@ -173,7 +173,7 @@ If one of the following errors appears during the run of the playbook, run the f
 - `Please add this host's fingerprint to your known_hosts file to manage this host.` - Indicates that an SSH password cannot be used instead of a key. 
   
   Fix:
-    :information_source: ##### *Note*: change `[YOUR_HOST]` to the target machine's network address
+  ##### *Note*: change `[YOUR_HOST]` to the target machine's network address
   ```shell
   ssh-keyscan -H [YOUR_HOST] >> ~/.ssh/known_hosts
   ```

--- a/README.md
+++ b/README.md
@@ -144,15 +144,15 @@ The sample playbook [`ibmmq.yml`](ansible_collections/ibm/ibmmq/ibmmq.yml) insta
 
     - On Mac:
 
-          ```shell
-           export ANSIBLE_LIBRARY=${ANSIBLE_LIBRARY}:<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
-          ```
+       ```shell
+          export ANSIBLE_LIBRARY=${ANSIBLE_LIBRARY}:<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
+       ```
 
-    - On Windows: 
-
-          ```shell
-           set ANSIBLE_LIBRARY=%ANSIBLE_LIBRARY%;<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
-          ```
+    - On Windows:
+    
+      ```shell
+          set ANSIBLE_LIBRARY=%ANSIBLE_LIBRARY%;<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
+       ```
 
 2. Run the following command to execute the tasks within the playbook:
       ```shell

--- a/README.md
+++ b/README.md
@@ -120,15 +120,13 @@ The sample playbook [`ibmmq.yml`](ansible_collections/ibm/ibmmq/ibmmq.yml) insta
            set ANSIBLE_LIBRARY=%ANSIBLE_LIBRARY%;<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
           ```
 
-2. Make sure you update the hosts in `ibmmq.yml` name to `YOUR_TARGET_MACHINES` group from your inventory file.
-
-3. Run the following command to execute the tasks within the playbook:
+2. Run the following command to execute the tasks within the playbook:
       ```shell
-       ansible-playbook ./ibmmq.yml -i inventory.ini -K
+       ansible-playbook ./ibmmq.yml -i inventory.ini [-K]
       ```
-      - ##### *NOTE* : `-K` will prompt the user to enter the sudo password for [YOUR_USER] on the target machine.
+      - ##### *NOTE* : `-K` will prompt the user to enter the sudo password for [YOUR_SSH_USER] on the target machine, you can omit if you have setup SSH keys.
 
-4. The playbook should return the result of `dspmq` with the queue manager created listed. Log into your target machine and check it manually:
+3. The playbook should return the result of `dspmq` with the queue manager created listed. Log into your target machine and check it manually:
 
     ```shell
      dspmq

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | :memo:        | Interested in contributing to this project? Please read our [IBM Contributor License Agreement](CLA.md) and our [Contributing Guide](CONTRIBUTING.md).       |
 |---------------|:------------------------|
 
-A collection for automating the installation and configuration of IBM MQ using Ansible on Ubuntu machines. Our aim is to make MQ-Ansible extensible for further and more detailed IBM MQ configuration.
+A collection for automating the installation and configuration of IBM MQ using Ansible on Ubuntu machines. Our aim is to make MQ-Ansible extensible for other platforms and more detailed IBM MQ configuration.
 
 This directory contains:
 - ansible [`roles`](https://github.com/ibm-messaging/mq-ansible/tree/main/ansible_collections/ibm/ibmmq/roles) for the installation and configuration of IBM MQ.
@@ -19,7 +19,7 @@ For a detailed explanation and documentation on how MQ-Ansible works, click [her
 
 ## Roles for IBM MQ installation
 
-The roles in this collection carry out an installation of IBM MQ Advanced on an Ubuntu target machine with ansible roles as yaml files. The roles have been implemented to set up the required users on the machine, download the software, install and configure IBM MQ, copy over a configurable `dev-config.mqsc` file ready to be run on the target machine, and set and start the web console. Developers can change this file to allow better configuration of their queue managers.
+The roles in this collection carryout an installation of IBM MQ Advanced on an Ubuntu target machine. The roles have been implemented to set up the required users on the machine, download the software, install and configure IBM MQ, copy over a configurable `dev-config.mqsc` file ready to be run on the target machine, and setup and start the web console. Developers can change this file to allow better configuration of their queue managers.
 
 
 ### Example
@@ -89,14 +89,16 @@ Before running the playbook implementing our modules and roles for IBM MQ:
 6. Create a file `inventory.ini` inside the directory with the following content:
   
     ```ini
-    [YOUR_TARGET_MACHINES]
-    [YOUR_MACHINE_IP] ansible_ssh_user=[YOUR_USER]
-    ```
+    
+    [servers]
+    server-alias-n ansible_host=[YOUR_HOSTNAME_n] ansible_ssh_user=[YOUR_SSH_USER]
+    server-alias-n ansible_host=[YOUR_HOSTNAME_n] ansible_ssh_user=[YOUR_SSH_USER]
 
-   - Change `YOUR_TARGET_MACHINES` to your machines' group name, for example `fyre`.
-   - Change `YOUR_MACHINE_IP` to your target machine's public IP
-   - Change `YOUR_USER` to your target machine's user.
-   ##### *NOTE* : user on the target machine MUST NOT be root but MUST have `sudo` privileges.
+    ```
+   - Change each `server-alias-n` to an alias name that you wish to use
+   - Change each `YOUR_HOSTNAME_n` to your server/hostname, for example: `myserver-1.fyre.com`.
+   - Change `YOUR_SSH_USER` to your target machine's SSH user.
+   ##### *NOTE* : the user on the target machine MUST have `sudo` privileges.
 
 ### ibmmq.yml
 
@@ -109,13 +111,13 @@ The sample playbook [`ibmmq.yml`](ansible_collections/ibm/ibmmq/ibmmq.yml) insta
     - On Mac:
 
           ```shell
-           export ANSIBLE_LIBRARY=<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
+           export ANSIBLE_LIBRARY=${ANSIBLE_LIBRARY}:<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
           ```
 
     - On Windows: 
 
           ```shell
-           set ANSIBLE_LIBRARY=<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
+           set ANSIBLE_LIBRARY=%ANSIBLE_LIBRARY%;<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
           ```
 
 2. Make sure you update the hosts in `ibmmq.yml` name to `YOUR_TARGET_MACHINES` group from your inventory file.
@@ -173,7 +175,7 @@ To run the test playbooks first:
      export ANSIBLE_LIBRARY=<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
     ```
    - ##### *NOTE* : change `<PATH-TO>` to your local directory path:
-3. run all test playbooks with `main.py`
+3. run all test playbooks with `python3 main.py`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ mq-setup.yml - this playbook sets up IBM MQ using the 'mqm' user
 
 # Run our sample playbook
 
-##### Note: *Ansible* must be installed on the local machine. ([Installation guide](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html))
+##### *Note*: *Ansible* must be installed on the local machine. ([Installation guide](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html))
 
 Before running the playbook and implementing our modules and roles for IBM MQ:
 
@@ -128,11 +128,11 @@ Before running the playbook and implementing our modules and roles for IBM MQ:
     YOUR_HOST_ALIAS ansible_host=YOUR_HOSTNAME ansible_ssh_user=YOUR_SSH_USER
 
     ```
-   :information_source: Note: You can specify one or more hosts.
+   ##### *Note*: You can specify one or more hosts.
    - Change `YOUR_HOST_ALIAS` to an alias name that you wish to use e.g. `mq-host-1` , you can omit aliases if you prefer
    - Change `YOUR_HOSTNAME` to your server/hostname, e.g. `myserver-1.fyre.com`
    - Change `YOUR_SSH_USER` to your target machine's SSH user
-   ##### *NOTE* : the user on the target machine MUST have `root` or `sudo` privileges.
+   ##### *Note*: the user on the target machine MUST have `root` or `sudo` privileges.
 
 ### ibmmq.yml
 
@@ -140,7 +140,7 @@ The sample playbook [`ibmmq.yml`](ansible_collections/ibm/ibmmq/ibmmq.yml) insta
 
 1. Before running the playbook, ensure that you have added the following directory path to the ANSIBLE_LIBRARY environment variable.
 
-    ##### *NOTE* : change `<PATH-TO>` to your local directory path:
+    ##### *NOTE*: change `<PATH-TO>` to your local directory path:
 
     - On Mac:
 
@@ -158,7 +158,7 @@ The sample playbook [`ibmmq.yml`](ansible_collections/ibm/ibmmq/ibmmq.yml) insta
       ```shell
        ansible-playbook ./ibmmq.yml -i inventory.ini [-K]
       ```
-      - ##### *NOTE* : The optional `-K` will prompt the user to enter the sudo password for [YOUR_SSH_USER] on the target machine, you can omit if you have setup SSH keys.
+      - ##### *Note*: The optional `-K` will prompt the user to enter the sudo password for [YOUR_SSH_USER] on the target machine, you can omit if you have setup SSH keys.
 
 3. The playbook should return the result of `dspmq` with the queue manager created listed. Log into your target machine and check it manually:
 
@@ -173,7 +173,7 @@ If one of the following errors appears during the run of the playbook, run the f
 - `Please add this host's fingerprint to your known_hosts file to manage this host.` - Indicates that an SSH password cannot be used instead of a key. 
   
   Fix:
-    ##### *NOTE* : change `[YOUR_HOST]` to the target machine's network address
+    :information_source: ##### *Note*: change `[YOUR_HOST]` to the target machine's network address
   ```shell
   ssh-keyscan -H [YOUR_HOST] >> ~/.ssh/known_hosts
   ```
@@ -206,7 +206,7 @@ To run the test playbooks first:
     ```shell
      export ANSIBLE_LIBRARY=<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
     ```
-   - ##### *NOTE* : change `<PATH-TO>` to your local directory path:
+   - ##### *Note*: change `<PATH-TO>` to your local directory path:
 3. run all test playbooks with `python3 main.py`
 
 ## License

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Before running the playbook and implementing our modules and roles for IBM MQ:
      ssh-keygen
     ```
 
-3. Once the keys have been generated, these need to be copied to the target machine's user `ssh` directory. 
+3. Once the keys have been generated, you need to copy the public key to the target machine's user `ssh` directory.
 
     ```shell
      ssh-copy-id -i id_rsa.pub [USER]@[YOUR_TARGET_HOST]
@@ -207,7 +207,7 @@ To run the test playbooks first:
     ```
 2. export the modules to your Ansible library
     ```shell
-     export ANSIBLE_LIBRARY=<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
+     export ANSIBLE_LIBRARY=${ANSIBLE_LIBRARY}:<PATH-TO>/ansible_mq/ansible_collections/ibm/ibmmq/library
     ```
    - ##### *Note*: change `<PATH-TO>` to your local directory path:
 3. run all test playbooks with `python3 main.py`

--- a/ansible_collections/ibm/ibmmq/ibmmq.yml
+++ b/ansible_collections/ibm/ibmmq/ibmmq.yml
@@ -1,4 +1,4 @@
-- name: Test
+- name: Install and setup IBM MQ
   hosts: ['servers']
 
 - name: Run the install playbook

--- a/ansible_collections/ibm/ibmmq/ibmmq.yml
+++ b/ansible_collections/ibm/ibmmq/ibmmq.yml
@@ -1,38 +1,8 @@
-- hosts: [YOUR_TARGET_MACHINES]
-  become: false
-  environment:
-    PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
+- name: Test
+  hosts: ['servers']
 
-  roles: 
-    - role: setupusers
-      vars:
-        gid: 999
-    - downloadmq
-    - installmq
-    - getconfig
-    - setupconsole
-    - startconsole
- 
-  tasks:
+- name: Run the install playbook
+  import_playbook: mq-install.yml
 
-    - name: Create a queue manager
-      queue_manager:
-        qmname: 
-        - 'QM1'
-        - 'QM2'
-        state: 'present'
- 
-    - name: Start a queue manager
-      queue_manager:
-        qmname:
-        - 'QM1'
-        - 'QM2'
-        state: 'running'
-
-    - name: Run MQSC File
-      queue_manager:
-        qmname:
-        - 'QM1'
-        - 'QM2'
-        state: 'running'
-        mqsc_file: '/home/{{ ansible_ssh_user }}/dev-config.mqsc'
+- name: Run the setup playbook
+  import_playbook: mq-setup.yml

--- a/ansible_collections/ibm/ibmmq/mq-install.yml
+++ b/ansible_collections/ibm/ibmmq/mq-install.yml
@@ -7,6 +7,7 @@
   roles: 
     - role: setupusers
       vars:
-        gid: 909
+        appUid: 909
+        appGid: 909
     - downloadmq
     - installmq

--- a/ansible_collections/ibm/ibmmq/mq-install.yml
+++ b/ansible_collections/ibm/ibmmq/mq-install.yml
@@ -1,0 +1,12 @@
+- hosts: "{{ ansible_play_batch }}" 
+  serial: 1
+  become: false
+  environment:
+    PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
+
+  roles: 
+    - role: setupusers
+      vars:
+        gid: 909
+    - downloadmq
+    - installmq

--- a/ansible_collections/ibm/ibmmq/mq-setup.yml
+++ b/ansible_collections/ibm/ibmmq/mq-setup.yml
@@ -1,0 +1,35 @@
+- hosts: "{{ ansible_play_hosts }}"
+  serial: 1
+  become: yes
+  become_user: mqm 
+  environment:
+    PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
+
+  roles: 
+    - getconfig
+    - setupconsole
+    - startconsole
+
+  tasks:
+
+    - name: Create a queue manager
+      queue_manager:
+        qmname: 
+        - 'QM1'
+        - 'QM2'
+        state: 'present'
+ 
+    - name: Start a queue manager
+      queue_manager:
+        qmname:
+        - 'QM1'
+        - 'QM2'
+        state: 'running'
+
+    - name: Run MQSC File
+      queue_manager:
+        qmname:
+        - 'QM1'
+        - 'QM2'
+        state: 'running'
+        mqsc_file: '/var/mqm/dev-config.mqsc'

--- a/ansible_collections/ibm/ibmmq/roles/downloadmq/tasks/main.yml
+++ b/ansible_collections/ibm/ibmmq/roles/downloadmq/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Download MQ Advanced for Developers
   get_url:
-    url: https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev920_ubuntu_x86-64.tar.gz
+    url: https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev931_ubuntu_x86-64.tar.gz
     dest: /tmp/mq.tar.gz
     force: no
   tags: download

--- a/ansible_collections/ibm/ibmmq/roles/downloadmq/tasks/main.yml
+++ b/ansible_collections/ibm/ibmmq/roles/downloadmq/tasks/main.yml
@@ -5,9 +5,11 @@
     url: https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev920_ubuntu_x86-64.tar.gz
     dest: /tmp/mq.tar.gz
     force: no
+  tags: download
 
 - name: Extract MQ fom TAR
   unarchive:
     src: /tmp/mq.tar.gz
     remote_src: yes
     dest: /tmp
+  tags: download

--- a/ansible_collections/ibm/ibmmq/roles/getconfig/tasks/main.yml
+++ b/ansible_collections/ibm/ibmmq/roles/getconfig/tasks/main.yml
@@ -3,4 +3,4 @@
 - name: Copy developer config file to target
   copy:
     src: ../../../dev-config.mqsc
-    dest: "/home/{{ ansible_ssh_user }}"
+    dest: "/var/mqm"

--- a/ansible_collections/ibm/ibmmq/roles/installmq/tasks/main.yml
+++ b/ansible_collections/ibm/ibmmq/roles/installmq/tasks/main.yml
@@ -44,17 +44,6 @@
     apt-get update
   changed_when: 'installed_mq_packages.stdout_lines | string is not search("ibmmq")'
 
-- name: Add the user to group mqm
-  become: true
-  shell: adduser ${SUDO_USER:-${USER}} mqm
-
-- name: Add the user to group mqm
-  become: true
-  user:
-    name: "{{ ansible_ssh_user }}"
-    groups: mqm
-    append: yes
-  
 - name: reset ssh connection
   meta: reset_connection
 

--- a/ansible_collections/ibm/ibmmq/roles/setupconsole/tasks/main.yml
+++ b/ansible_collections/ibm/ibmmq/roles/setupconsole/tasks/main.yml
@@ -1,46 +1,25 @@
 ---
 
-- name: Check if basic registry exists
+- name: Check if basic registry exists in the install folder
   stat:
     path: /opt/mqm/web/mq/samp/configuration/basic_registry.xml
   register: basic_registry_result
 
-- name: Moving basic registry
-  become: true
-  shell: mv /opt/mqm/web/mq/samp/configuration/basic_registry.xml /var/mqm/web/installations/Installation1/servers/mqweb/
-  when: basic_registry_result.stat.exists
-
-- name: Check if old mqwebuser exists
-  stat:
-    path: /var/mqm/web/installations/Installation1/servers/mqweb/mqwebuser.old
-  register: mqwebuser_result
-
-- name: moving mqwebuser to old mqwebuser
-  become: true
-  shell: mv /var/mqm/web/installations/Installation1/servers/mqweb/mqwebuser.xml /var/mqm/web/installations/Installation1/servers/mqweb/mqwebuser.old
-  when: not mqwebuser_result.stat.exists
-
-- name: Check if moved basic registry exists
-  stat:
-    path: /var/mqm/web/installations/Installation1/servers/mqweb/basic_registry.xml
-  register: moved_registry
-
-- name: Using basic_registry as webwebuser
-  become: true
-  shell: mv /var/mqm/web/installations/Installation1/servers/mqweb/basic_registry.xml /var/mqm/web/installations/Installation1/servers/mqweb/mqwebuser.xml
-  when: moved_registry.stat.exists
-
-- name: Check correct mqwebuser exists
+- name: Check if mqwebuser already exists in target folder
   stat:
     path: /var/mqm/web/installations/Installation1/servers/mqweb/mqwebuser.xml
-  register: final_mqwebuser
+  register: target_mqwebuser_result
 
-- name: ensure correct permissions for mqwebuser.xml
+- name: Set permissions to allow overwrite of target mqwebuser.xml if it already exists
   become: true
   shell: chmod 640 /var/mqm/web/installations/Installation1/servers/mqweb/mqwebuser.xml
-  when: final_mqwebuser.stat.exists
+  when: target_mqwebuser_result.stat.exists
 
-- name: ensure correct permissions for mqwebuser.xml
+- name: Copying basic registry
   become: true
-  shell: chown {{ ansible_ssh_user }} /var/mqm/web/installations/Installation1/servers/mqweb/mqwebuser.xml
-  when: final_mqwebuser.stat.exists
+  shell: cp /opt/mqm/web/mq/samp/configuration/basic_registry.xml /var/mqm/web/installations/Installation1/servers/mqweb/mqwebuser.xml
+  when: basic_registry_result.stat.exists
+
+- name: ensure correct permissions for mqwebuser.xml to allow setmqweb commands
+  become: true
+  shell: chmod 640 /var/mqm/web/installations/Installation1/servers/mqweb/mqwebuser.xml

--- a/ansible_collections/ibm/ibmmq/roles/setupusers/defaults/main.yml
+++ b/ansible_collections/ibm/ibmmq/roles/setupusers/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 
-gid:  989
+appUid: 909
+appGid: 909
+mqmUid: 2001
+mqmGid: 2001

--- a/ansible_collections/ibm/ibmmq/roles/setupusers/tasks/main.yml
+++ b/ansible_collections/ibm/ibmmq/roles/setupusers/tasks/main.yml
@@ -16,3 +16,9 @@
     password: "{{ 'apppassword' | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}"
     uid: "{{ gid }}"
     group: mqclient
+    
+- name: Create an admin user
+  user:
+    name: mqadm
+    groups: mqm
+    append: yes

--- a/ansible_collections/ibm/ibmmq/roles/setupusers/tasks/main.yml
+++ b/ansible_collections/ibm/ibmmq/roles/setupusers/tasks/main.yml
@@ -1,11 +1,28 @@
 ---
 
+- name: Create mqm group
+  group:
+    name: mqm
+    gid: "{{ mqmGid }}"
+
+- name: Create mqm user
+  user:
+    name: mqm
+    uid: "{{ mqmUid }}"
+    group: mqm
+
+- name: Create an admin user
+  user:
+    name: mqadm
+    groups: mqm
+    append: yes
+
 - name: Add 'mqclient' group
   become: true
   group:
     name: mqclient
     state: present
-    gid: "{{ gid }}"
+    gid: "{{ appGid }}"
 
 - name: Add the user 'app' with a specific UID
   become: true
@@ -14,11 +31,8 @@
   user:
     name: app
     password: "{{ 'apppassword' | password_hash('sha512', 65534 | random(seed=inventory_hostname) | string) }}"
-    uid: "{{ gid }}"
+    uid: "{{ appUid }}"
     group: mqclient
-    
-- name: Create an admin user
-  user:
-    name: mqadm
-    groups: mqm
-    append: yes
+
+
+

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/ibmmq_travis.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/ibmmq_travis.yml
@@ -35,5 +35,5 @@
         - 'QM1'
         - 'QM2'
         state: 'running'
-        mqsc_file: '/home/{{ ansible_ssh_user }}/dev-config.mqsc'
+        mqsc_file: '/var/mqm/dev-config.mqsc'
 

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_install.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_install.yml
@@ -66,7 +66,7 @@
 
     - name: get dev config
       stat: 
-        path: "/home/{{ ansible_ssh_user }}/dev-config.mqsc"
+        path: "/var/mqm/dev-config.mqsc"
       register: testout_dev_config_copied
     - name: test dev config exists
       assert:


### PR DESCRIPTION
Modified playbooks to allow installation using a privileged account and then to use the 'mqm' user to create, start queue manager, start web console etc.

Updated documentation to reflect all changes and made some minor fixes to instructions.

Added an 'mqadm' user for general admin tasks.

Copy MQSC file to /var/mqm instead of install user's home folder.