### PR TITLE
Add MQ download version variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ibmmq.yml - this playbook calls the mq-install and mq-setup playbooks, host name
 ```
 
 mq-install.yml - this playbook installs IBM MQ with the SSH user specified in the inventory
-
+##### *Note*: The MQ *version* and user *GID* can be specified here.
 ```yaml
 - hosts: "{{ ansible_play_batch }}"
   serial: 1
@@ -51,7 +51,9 @@ mq-install.yml - this playbook installs IBM MQ with the SSH user specified in th
     - role: setupusers
       vars:
         gid: 909
-    - downloadmq
+    - role: downloadmq
+      vars:
+        version: 930
     - installmq
 ```
 mq-setup.yml - this playbook sets up IBM MQ using the 'mqm' user

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ibmmq.yml - this playbook calls the mq-install and mq-setup playbooks, host name
 ```
 
 mq-install.yml - this playbook installs IBM MQ with the SSH user specified in the inventory
-##### *Note*: The MQ *version* and user *GID* can be specified here.
+##### *Note*: The MQ *version* and app user's *UID and GID* can be specified here.
 ```yaml
 - hosts: "{{ ansible_play_batch }}"
   serial: 1
@@ -50,11 +50,13 @@ mq-install.yml - this playbook installs IBM MQ with the SSH user specified in th
   roles:
     - role: setupusers
       vars:
-        gid: 909
+        appUid: 909
+        appGid: 909
+        mqmHome: /home/mqm
+        mqmProfile: .profile
     - role: downloadmq
       vars:
         version: 930
-    - installmq
 ```
 mq-setup.yml - this playbook sets up IBM MQ using the 'mqm' user
 

--- a/ansible_collections/ibm/ibmmq/mq-install.yml
+++ b/ansible_collections/ibm/ibmmq/mq-install.yml
@@ -11,5 +11,7 @@
         appGid: 909
         mqmHome: /home/mqm
         mqmProfile: .profile
-    - downloadmq
+    - role: downloadmq
+      vars:
+        version: 930
     - installmq

--- a/ansible_collections/ibm/ibmmq/roles/downloadmq/tasks/main.yml
+++ b/ansible_collections/ibm/ibmmq/roles/downloadmq/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Download MQ Advanced for Developers
   get_url:
-    url: https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev931_ubuntu_x86-64.tar.gz
+    url: "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev{{ version }}_ubuntu_x86-64.tar.gz"
     dest: /tmp/mq.tar.gz
     force: no
   tags: download


### PR DESCRIPTION
A quick change to extract the mq version from the download link and supply it within mq-install.yml - something that was raised in our meeting with MQ stakeholders.