### PR TITLE
Test Playbook Enhancements

### DIFF
--- a/ansible_collections/ibm/ibmmq/tests/playbooks/cleanup_test.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/cleanup_test.yml
@@ -1,6 +1,7 @@
 - name: cleanup after tests
   hosts: all
-  become: false
+  become: yes
+  become_user: mqm
   environment:
     PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
   tasks:

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/main.py
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/main.py
@@ -4,6 +4,7 @@
 
 import subprocess
 subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_install.yml'])
+subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'setup_test.yml'])
 subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_absent_qmgr.yml'])
 subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_present_qmgr.yml'])
 subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_running_qmgr.yml'])

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/main.py
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/main.py
@@ -21,18 +21,39 @@ if rc.returncode == 0:
                             if rc.returncode == 0:
                                 print("<---- All Tests Completed Successfully ---->")
                             else:
-                                print("<---- cleanup_test.yml failed ---->")
+                                print("<---- FATAL: cleanup_test.yml failed ---->")
                         else:
+                            rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'cleanup_test.yml'])
                             print("<---- test_web_console.yml failed ---->")
+                            if rc.returncode != 0:
+                                print("<---- FATAL: cleanup_test.yml failed ---->")
                     else:
+                        rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'cleanup_test.yml'])
                         print("<---- test_misc.yml failed ---->")
+                        if rc.returncode != 0:
+                            print("<---- FATAL: cleanup_test.yml failed ---->")
                 else:
+                    rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'cleanup_test.yml'])
                     print("<---- test_running_qmgr.yml failed ---->")
+                    if rc.returncode != 0:
+                        print("<---- FATAL: cleanup_test.yml failed ---->")
             else:
+                rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'cleanup_test.yml'])
                 print("<---- test_present_qmgr.yml failed ---->")
+                if rc.returncode != 0:
+                    print("<---- FATAL: cleanup_test.yml failed ---->")
         else:
+            rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'cleanup_test.yml'])
             print("<---- test_absent_qmgr.yml failed ---->")
+            if rc.returncode != 0:
+                print("<---- FATAL: cleanup_test.yml failed ---->")
     else:
+        rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'cleanup_test.yml'])
         print("<---- setup_test.yml failed ---->")
+        if rc.returncode != 0:
+            print("<---- FATAL: cleanup_test.yml failed ---->")
 else:
+    rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'cleanup_test.yml'])
     print("<---- test_install.yml failed ---->")
+    if rc.returncode != 0:
+        print("<---- FATAL: cleanup_test.yml failed ---->")

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/main.py
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/main.py
@@ -3,11 +3,36 @@
 # create your own inventory file
 
 import subprocess
-subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_install.yml'])
-subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'setup_test.yml'])
-subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_absent_qmgr.yml'])
-subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_present_qmgr.yml'])
-subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_running_qmgr.yml'])
-subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_misc.yml'])
-subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_web_console.yml'])
-subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'cleanup_test.yml'])
+rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_install.yml', '--extra-vars', 'ibmMqLicence=accept'])
+if rc.returncode == 0:
+    rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'setup_test.yml'])
+    if rc.returncode == 0:
+        rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_absent_qmgr.yml'])
+        if rc.returncode == 0:
+            rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_present_qmgr.yml'])
+            if rc.returncode == 0:
+                rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_running_qmgr.yml'])
+                if rc.returncode == 0:
+                    rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_misc.yml'])
+                    if rc.returncode == 0:
+                        rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'test_web_console.yml'])
+                        if rc.returncode == 0:
+                            rc = subprocess.run(['ansible-playbook', '--inventory', 'inventory.ini', 'cleanup_test.yml'])
+                            if rc.returncode == 0:
+                                print("<---- All Tests Completed Successfully ---->")
+                            else:
+                                print("<---- cleanup_test.yml failed ---->")
+                        else:
+                            print("<---- test_web_console.yml failed ---->")
+                    else:
+                        print("<---- test_misc.yml failed ---->")
+                else:
+                    print("<---- test_running_qmgr.yml failed ---->")
+            else:
+                print("<---- test_present_qmgr.yml failed ---->")
+        else:
+            print("<---- test_absent_qmgr.yml failed ---->")
+    else:
+        print("<---- setup_test.yml failed ---->")
+else:
+    print("<---- test_install.yml failed ---->")

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/setup_test.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/setup_test.yml
@@ -1,6 +1,7 @@
 - name: Setup for tests
   hosts: all
-  become: false
+  become: yes
+  become_user: mqm
   environment:
     PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
   tasks:
@@ -8,4 +9,4 @@
   - name: Copy MQSC file to container
     copy:
       src: mqsc_display
-      dest: /home/{{ ansible_ssh_user }}
+      dest: "/var/mqm/mqsc_display"

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_absent_qmgr.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_absent_qmgr.yml
@@ -1,6 +1,7 @@
 - name: tests when absent (1)
   hosts: all
-  become: false
+  become: yes
+  become_user: mqm
   environment:
     PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
   tasks:

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_install.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_install.yml
@@ -1,6 +1,6 @@
 - name: test downloading and installing MQ
   hosts: all
-  become: yes
+  become: true
   environment:
     PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
 

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_install.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_install.yml
@@ -1,6 +1,6 @@
 - name: test downloading and installing MQ
   hosts: docker
-  become: true
+  become: yes
   environment:
     PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
 
@@ -13,7 +13,7 @@
     - name: Copy developer config file to target
       copy:
         src: ../../dev-config.mqsc
-        dest: /home/{{ ansible_ssh_user }}
+        dest: "/var/mqm/dev-config.mqsc"
 
     - name: get 'mqclient' group
       shell: getent group mqclient

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_install.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_install.yml
@@ -5,8 +5,8 @@
     PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
 
   roles: 
-    - { role: ../../roles/setupusers }
-    - { role: ../../roles/downloadmq }
+    - { role: ../../roles/setupusers, appUid: 909, appGid: 909, mqmHome: /home/mqm, mqmProfile: .profile}
+    - { role: ../../roles/downloadmq, version: 930 }
     - { role: ../../roles/installmq }
 
   tasks:

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_misc.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_misc.yml
@@ -88,7 +88,7 @@
     queue_manager:
       qmname: qm1_misc_2
       state: running
-      mqsc_file: mqsc_display
+      mqsc_file: '/var/mqm/mqsc_display'
     register: testout_1
     failed_when: False
   - name: dump run output

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_misc.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_misc.yml
@@ -1,6 +1,7 @@
 - name: misc tests (4)
   hosts: all
-  become: false
+  become: yes
+  become_user: mqm
   environment:
     PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
   tasks:

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_present_qmgr.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_present_qmgr.yml
@@ -65,7 +65,7 @@
     queue_manager:
       qmname: 'qm1_present_mqsc'
       state: 'present'
-      mqsc_file: mq-dev-config.mqsc
+      mqsc_file: '/var/mqm/mq-dev-config.mqsc'
     register: testout_3
     failed_when: False
   - name: dump test output

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_present_qmgr.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_present_qmgr.yml
@@ -1,6 +1,7 @@
 - name: test QMGR present
   hosts: all
-  become: false
+  become: yes
+  become_user: mqm
   environment:
     PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
   tasks:

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_running_qmgr.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_running_qmgr.yml
@@ -19,7 +19,7 @@
     queue_manager:
       qmname: 'qm1_running'
       state: 'present'
-      mqsc_file: mqsc_display
+      mqsc_file: '/var/mqm/mqsc_display'
     register: testout
     failed_when: False
   - name: dump test output
@@ -36,7 +36,7 @@
     queue_manager:
       qmname: 'qm1_running'
       state: 'running'
-      mqsc_file: mqsc_display
+      mqsc_file: '/var/mqm/mqsc_display'
     register: testout
     failed_when: False
   - name: dump test output

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_running_qmgr.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_running_qmgr.yml
@@ -1,6 +1,7 @@
 - name: tests when running (3)
   hosts: all
-  become: false
+  become: yes
+  become_user: mqm
   environment:
     PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
   tasks:

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_web_console.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_web_console.yml
@@ -1,6 +1,7 @@
 - name: test downloading and installing MQ
   hosts: docker
-  become: false
+  become: yes
+  become_user: mqm
   environment:
     PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
 


### PR DESCRIPTION
Modified the appropriate test playbooks to be run by mqm (the install test is still run by root).

The mqsc files used in testing are now copied to /var/mqm so that they are accessible by any user.