### PR TITLE
Ansible lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,48 @@
+# This makes linter to fully ignore rules/tags listed below
+skip_list:
+  - fqcn-builtins # For the sake of readability
+  - empty-string-compare
+
+# Any rule that has the 'opt-in' tag will not be loaded unless its 'id' is
+# mentioned in the enable_list:
+enable_list:
+  - no-log-password # opt-in
+  - no-same-owner # opt-in
+  # https://github.com/ansible/ansible-lint/issues/457
+  # add yaml here if you want to avoid ignoring yaml checks when yamllint
+  # library is missing. Normally its absence just skips using that rule.
+  - yaml
+
+# Report only a subset of tags and fully ignore any others
+# tags:
+#   - var-spacing
+
+# This makes the linter display but not fail for rules/tags listed below:
+warn_list:
+  - experimental # experimental is included in the implicit list
+  # - skip_this_tag
+  # - git-latest
+  # - role-name
+
+# Some rules can transform files to fix (or make it easier to fix) identified
+# errors. `ansible-lint --write` will reformat YAML files and run these transforms.
+# By default it will run all transforms (effectively `write_list: ["all"]`).
+# You can disable running transforms by setting `write_list: ["none"]`.
+# Or only enable a subset of rule transforms by listing rules/tags here.
+# write_list:
+#   - all
+
+# Offline mode disables installation of requirements.yml
+offline: false
+
+# Define required Ansible's variables to satisfy syntax check
+# extra_vars:
+  # foo: bar
+  # multiline_string_variable: |
+  #   line1
+  #   line2
+  # complex_variable: ":{;\t$()"
+
+# Uncomment to enforce action validation with tasks, usually is not
+# needed as Ansible syntax check also covers it.
+# skip_action_validation: false

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -76,8 +76,8 @@ warn_list:
 # By default it will run all transforms (effectively `write_list: ["all"]`).
 # You can disable running transforms by setting `write_list: ["none"]`.
 # Or only enable a subset of rule transforms by listing rules/tags here.
-# write_list:
-#   - all
+write_list:
+  - all
 
 # Offline mode disables installation of requirements.yml and schema refreshing
 offline: false

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,28 +1,75 @@
-# This makes linter to fully ignore rules/tags listed below
+profile: null # min, basic, moderate,safety, shared, production
+
+# Allows dumping of results in SARIF format
+# sarif_file: result.sarif
+
+# exclude_paths included in this file are parsed relative to this file's location
+# and not relative to the CWD of execution. CLI arguments passed to the --exclude
+# option are parsed relative to the CWD of execution.
+exclude_paths:
+  - .cache/ # implicit unless exclude_paths is defined in config
+  - .github/
+  # - test/fixtures/formatting-before/
+  # - test/fixtures/formatting-prettier/
+# parseable: true
+# quiet: true
+# strict: true
+# verbosity: 1
+
+# Mock modules or roles in order to pass ansible-playbook --syntax-check
+mock_modules:
+  - queue_manager
+  # note the foo.bar is invalid as being neither a module or a collection
+  # - fake_namespace.fake_collection.fake_module
+  # - fake_namespace.fake_collection.fake_module.fake_submodule
+# mock_roles:
+  # - mocked_role
+  # - author.role_name # old standalone galaxy role
+  # - fake_namespace.fake_collection.fake_role # role within a collection
+
+# Enable checking of loop variable prefixes in roles
+loop_var_prefix: "^(__|{role}_)"
+
+# Enforce variable names to follow pattern below, in addition to Ansible own
+# requirements, like avoiding python identifiers. To disable add `var-naming`
+# to skip_list.
+var_naming_pattern: "^[a-z_][a-z0-9_]*$"
+
+use_default_rules: true
+# Load custom rules from this specific folder
+# rulesdir:
+#   - ./rule/directory/
+
+# Ansible-lint is able to recognize and load skip rules stored inside
+# `.ansible-lint-ignore` (or `.config/ansible-lint-ignore.txt`) files.
+# To skip a rule just enter filename and tag, like "playbook.yml package-latest"
+# on a new line.
+# Optionally you can add comments after the tag, prefixed by "#". We discourage
+# the use of skip_list below because that will hide violations from the output.
+# When putting ignores inside the ignore file, they are marked as ignored, but
+# still visible, making it easier to address later.
 skip_list:
   - fqcn-builtins # For the sake of readability
   - empty-string-compare
 
-# Any rule that has the 'opt-in' tag will not be loaded unless its 'id' is
-# mentioned in the enable_list:
+# Ansible-lint does not automatically load rules that have the 'opt-in' tag.
+# You must enable opt-in rules by listing each rule 'id' below.
 enable_list:
+  - args
   - no-log-password # opt-in
   - no-same-owner # opt-in
-  # https://github.com/ansible/ansible-lint/issues/457
   # add yaml here if you want to avoid ignoring yaml checks when yamllint
   # library is missing. Normally its absence just skips using that rule.
   - yaml
-
 # Report only a subset of tags and fully ignore any others
 # tags:
-#   - var-spacing
+#   - jinja[spacing]
 
-# This makes the linter display but not fail for rules/tags listed below:
+# Ansible-lint does not fail on warnings from the rules or tags listed below
 warn_list:
   - experimental # experimental is included in the implicit list
-  # - skip_this_tag
-  # - git-latest
   # - role-name
+  # - yaml[document-start]  # you can also use sub-rule matches
 
 # Some rules can transform files to fix (or make it easier to fix) identified
 # errors. `ansible-lint --write` will reformat YAML files and run these transforms.
@@ -32,17 +79,45 @@ warn_list:
 # write_list:
 #   - all
 
-# Offline mode disables installation of requirements.yml
+# Offline mode disables installation of requirements.yml and schema refreshing
 offline: false
 
+# Return success if number of violations compared with previous git
+# commit has not increased. This feature works only in git
+# repositories.
+progressive: false
+
 # Define required Ansible's variables to satisfy syntax check
-# extra_vars:
-  # foo: bar
-  # multiline_string_variable: |
-  #   line1
-  #   line2
-  # complex_variable: ":{;\t$()"
+extra_vars:
+  foo: bar
+  multiline_string_variable: |
+    line1
+    line2
+  complex_variable: ":{;\t$()"
 
 # Uncomment to enforce action validation with tasks, usually is not
 # needed as Ansible syntax check also covers it.
 # skip_action_validation: false
+
+# List of additional kind:pattern to be added at the top of the default
+# match list, first match determines the file kind.
+kinds:
+  # - playbook: "**/examples/*.{yml,yaml}"
+  - playbook: "**/ibmmq/*.{yml,yaml}"
+  - playbook: "**/playbooks/*.{yml,yaml}"
+  # - galaxy: "**/folder/galaxy.yml"
+  - tasks: "**/tasks/*.yml"
+  - vars: "**/vars/*.yml"
+  - meta: "**/meta/main.yml"
+  # - yaml: "**/*.yaml-too"
+
+# List of additional collections to allow in only-builtins rule.
+# only_builtins_allow_collections:
+#   - example_ns.example_collection
+
+# List of additions modules to allow in only-builtins rule.
+# only_builtins_allow_modules:
+#   - example_module
+
+# Allow setting custom prefix for name[prefix] rule
+task_name_prefix: "{stem} | "


### PR DESCRIPTION
Closes #23

`ansible-lint` can be installed on the ansible host using `pip install ansible-lint`.
There is also a Ansible's VSCode extension also highlights `ansible-lint` errors live in your editor: [https://marketplace.visualstudio.com/items?itemName=redhat.ansible](https://marketplace.visualstudio.com/items?itemName=redhat.ansible)

From running a quick scan using the command `ansible-lint`... The result was:
**Finished with 129 failure(s), 13 warning(s) on 43 files.**