### PR TITLE
add roles path to ansible.cfg and update tests

### DIFF
--- a/ansible_collections/ibm/ibmmq/tests/playbooks/ansible.cfg
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 host_key_checking = false
+roles_path = ../../roles

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_install.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_install.yml
@@ -5,15 +5,21 @@
     PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
 
   roles: 
-    - { role: ../../roles/setupusers, appUid: 909, appGid: 909, mqmHome: /home/mqm, mqmProfile: .profile}
-    - { role: ../../roles/downloadmq, version: 930 }
-    - { role: ../../roles/installmq }
+    - role: setupusers
+      vars:
+        appUid: 909
+        gid: 909
+        appGid: 909
+        mqmHome: /home/mqm
+        mqmProfile: .profile
+    - role: downloadmq
+      vars:
+        version: 930
+        downloadURL: "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/"
+    - installmq
+    - getconfig
 
   tasks:
-    - name: Copy developer config file to target
-      copy:
-        src: ../../dev-config.mqsc
-        dest: "/var/mqm/dev-config.mqsc"
 
     - name: get 'mqclient' group
       shell: getent group mqclient
@@ -33,7 +39,7 @@
 
     - name: get mq download zip
       stat:
-        path: /tmp/mq.tar.gz
+        path: /var/mq.tar.gz
       register: testout_mq_downloaded
     - name: test mq is downloaded
       assert:
@@ -42,7 +48,7 @@
 
     - name: get mq unarchived directory
       stat:
-        path: /tmp/MQServer
+        path: /var/MQServer
       register: testout_mq_unarchived
     - name: test mq is unarchived
       assert:
@@ -50,7 +56,7 @@
           testout_mq_unarchived.stat.isdir
 
     - name: Check license status
-      shell: cat /tmp/MQServer/licensestatus.txt
+      shell: cat /var/MQServer/licensestatus.txt
       register: test_out_accepted
 
     - name: test licence accepted
@@ -64,12 +70,19 @@
       assert:
         that: '{{ testout_mq_version }} is search("LicenseType: Developer")'
 
-    - name: get dev config
+    - name: get dev config (Linux)
       stat: 
         path: "/var/mqm/dev-config.mqsc"
-      register: testout_dev_config_copied
+      register: testout_dev_config_copied_linux
+      when: ansible_system == 'Linux'
+    - name: get dev config (AIX)
+      stat: 
+        path: "/tmp/dev-config.mqsc"
+      register: testout_dev_config_copied_aix
+      when: ansible_system != 'Linux'
+    
     - name: test dev config exists
       assert:
         that:
-          testout_dev_config_copied.stat.exists
+          testout_dev_config_copied_linux.stat.exists or testout_dev_config_copied_aix.stat.exists
     

--- a/ansible_collections/ibm/ibmmq/tests/playbooks/test_web_console.yml
+++ b/ansible_collections/ibm/ibmmq/tests/playbooks/test_web_console.yml
@@ -5,8 +5,8 @@
     PATH: /opt/mqm/bin:{{ ansible_env.PATH }}
 
   roles:
-    - { role: ../../roles/setupconsole }
-    - { role: ../../roles/startconsole }
+    - setupconsole
+    - startconsole
 
   tasks:
     - name: get mqwebuser


### PR DESCRIPTION
Adds in a relative path to the roles for the testing framework, making them accessible in our playbook tests. Also updates the test to use the `getconfig` role and checks the appropriate location for this depending on Linux/AIX

Closes #50