### PR TITLE
configure roles path, modify getconfig

### DIFF
--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ../roles

--- a/roles/getconfig/tasks/AIX_getconfig.yml
+++ b/roles/getconfig/tasks/AIX_getconfig.yml
@@ -2,6 +2,6 @@
 - name: Copy developer config file to target
   become: true
   ansible.builtin.copy:
-    src: ../../../dev-config.mqsc
+    src: ../../../playbooks/files/dev-config.mqsc
     dest: /tmp/dev-config.mqsc
     mode: "0644"

--- a/roles/getconfig/tasks/Linux_getconfig.yml
+++ b/roles/getconfig/tasks/Linux_getconfig.yml
@@ -1,6 +1,6 @@
 ---
 - name: Copy developer config file to target
   ansible.builtin.copy:
-    src: ../../../dev-config.mqsc
+    src: ../../../playbooks/files/dev-config.mqsc
     dest: /var/mqm
     mode: "0644"


### PR DESCRIPTION
Resolves #75 .
Uses an Ansible.cfg file to point out the location of the roles/ folder.