### PR TITLE
Removing/Replacing redundant ssh connection reset for linux and aix

### DIFF
--- a/roles/installmq/tasks/AIX_installmq.yml
+++ b/roles/installmq/tasks/AIX_installmq.yml
@@ -70,6 +70,3 @@
   changed_when: true
   ansible.builtin.shell: |
     chuser groups=mqm "{{ ansible_ssh_user }}"
-
-- name: Reset ssh connection
-  ansible.builtin.meta: reset_connection

--- a/roles/installmq/tasks/Linux_installmq.yml
+++ b/roles/installmq/tasks/Linux_installmq.yml
@@ -83,6 +83,3 @@
     - ansible_distribution == 'Ubuntu'
     - "'ibmmq-runtime' not in ansible_facts.packages"
   loop: "{{ package_list }}"
-
-- name: Reset ssh connection
-  ansible.builtin.meta: reset_connection


### PR DESCRIPTION
#90 
Looking into either replacing or removing the ssh connection reset in order to prevent loss of connection in instances where it can't be re-established easily. 

Will look into removing the command entirely first and making sure it still installs successfully, if that doesn't work a potential work around is for the user to switch user to itself 
via `su yourself`
this should refresh the user without the need to drop the ssh connection.