### PR TITLE
endmqweb failed_when condition

### DIFF
--- a/roles/applyfixpack/tasks/Linux_applyfixpack.yml
+++ b/roles/applyfixpack/tasks/Linux_applyfixpack.yml
@@ -44,7 +44,7 @@
   become_user: mqm
   ansible.builtin.command: endmqweb
   register: mqweb_status
-  failed_when: mqweb_status.rc != 0
+  failed_when: mqweb_status.stderr != ""
 
 - name: Find required package files
   ansible.builtin.find:

--- a/roles/applyfixpack/tasks/Linux_applyfixpack.yml
+++ b/roles/applyfixpack/tasks/Linux_applyfixpack.yml
@@ -44,7 +44,7 @@
   become_user: mqm
   ansible.builtin.command: endmqweb
   register: mqweb_status
-  failed_when: '"Server mqweb is not running" not in mqweb_status.stdout'
+  failed_when: mqweb_status.rc != 0
 
 - name: Find required package files
   ansible.builtin.find:


### PR DESCRIPTION
Previously, the endmqweb command in `Linux_applyfixpack.yml` would rely on stdout to check whether the web console needed to be stopped. It would work for if the web console was not running, but would fail when other stdout such as 'web console stopped' would be output. 

This change just updates the `failed_when` condition for that task to only fail if the return code for endmqweb is not 0