### PR TITLE
Added support for 9.4 LTS

### DIFF
--- a/playbooks/mq-install.yml
+++ b/playbooks/mq-install.yml
@@ -15,7 +15,7 @@
         mqm_profile: .profile
     - role: downloadmq
       vars:
-        version: 930
+        version: 940
         downloadURL: https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/
     - role: installmq
     - role: setupenvironment

--- a/roles/downloadmq/tasks/Linux_x86_64_downloadmq.yml
+++ b/roles/downloadmq/tasks/Linux_x86_64_downloadmq.yml
@@ -1,26 +1,26 @@
 ---
 
-# Set zip filename for LTS releases
-- name: Set filename of zip if target host is Ubuntu (LTS naming convention)
+# Set zip filename for releases with old naming convention
+- name: Set filename of zip if target host is Ubuntu (old naming convention)
   ansible.builtin.set_fact:
     zip_file: mqadv_dev{{ version }}_ubuntu_x86-64.tar.gz
-  when: ansible_distribution == 'Ubuntu' and not local_source and release=='lts'
+  when: ansible_distribution == 'Ubuntu' and not local_source and convention=='old'
 
-- name: Set filename of zip if target host is RedHat (LTS naming convention)
+- name: Set filename of zip if target host is RedHat (old naming convention)
   ansible.builtin.set_fact:
     zip_file: mqadv_dev{{ version }}_linux_x86-64.tar.gz
-  when: ansible_distribution == 'RedHat' and not local_source and release=='lts'
+  when: ansible_distribution == 'RedHat' and not local_source and convention=='old'
 
-# Set zip filename for CD releases
-- name: Set filename of zip if target host is Ubuntu (CD naming convention)
+# Set zip filename for releases with new naming convention (>9.3)
+- name: Set filename of zip if target host is Ubuntu (new naming convention)
   ansible.builtin.set_fact:
     zip_file: '{{ vrmf }}-IBM-MQ-Advanced-for-Developers-UbuntuLinuxX64.tar.gz'
-  when: ansible_distribution == 'Ubuntu' and not local_source and release=='cd'
+  when: ansible_distribution == 'Ubuntu' and not local_source and convention=='new'
 
-- name: Set filename of zip if target host is RedHat (CD naming convention)
+- name: Set filename of zip if target host is RedHat (new naming convention)
   ansible.builtin.set_fact:
     zip_file: '{{ vrmf }}-IBM-MQ-Advanced-for-Developers-LinuxX64.tar.gz   '
-  when: ansible_distribution == 'RedHat' and not local_source and release=='cd'
+  when: ansible_distribution == 'RedHat' and not local_source and convention=='new'
 
 # Get the file if local source is false
 - name: Download MQ Advanced for Developers

--- a/roles/downloadmq/tasks/Win32NT_64-bit_downloadmq.yml
+++ b/roles/downloadmq/tasks/Win32NT_64-bit_downloadmq.yml
@@ -2,17 +2,17 @@
 - name: Including specific vars for Windows
   ansible.builtin.include_vars: "{{ ansible_system }}_{{ ansible_architecture }}_{{ role_name }}.yml"
 
-# Set zip filename for LTS releases
-- name: Set filename of zip if target host is Windows (LTS naming convention)
+# Set zip filename for releases with old naming convention
+- name: Set filename of zip if target host is Windows (old naming convention)
   ansible.builtin.set_fact:
     zipFile: mqadv_dev{{ version }}_windows.zip
-  when: ansible_os_family == 'Windows' and not local_source and release=='lts'
+  when: ansible_os_family == 'Windows' and not local_source and convention=='old'
 
-# Set zip filename for CD releases
-- name: Set filename of zip if target host is Windows (CD naming convention)
+# Set zip filename for releases with new naming convention (>9.3)
+- name: Set filename of zip if target host is Windows (new naming convention)
   ansible.builtin.set_fact:
     zipFile: '{{ vrmf }}-IBM-MQ-Advanced-for-Developers-Win64.zip'
-  when: ansible_os_family == 'Windows' and not local_source and release=='cd'
+  when: ansible_os_family == 'Windows' and not local_source and convention=='new'
 
 - name: Download MQ Advanced for Developers on Windows
   ansible.windows.win_get_url:

--- a/roles/downloadmq/tasks/main.yml
+++ b/roles/downloadmq/tasks/main.yml
@@ -2,33 +2,38 @@
 - name: Including common vars for each platform
   ansible.builtin.include_vars: "common_{{ role_name }}.yml"
 
-# Set release types based on version mod, useful for different naming conventions
-- name: Set release type to LTS
+# Set convention types based on release version (new for >9.3 releases)
+- name: Set convention type to old for 9.3 and 9.2 LTS
   ansible.builtin.set_fact:
-    release: lts
-  when: version%10 == 0 
+    convention: old
+  when: version==930 or version==920
 
-- name: Set release type to CD
+- name: Set convention type to new to other releases
   ansible.builtin.set_fact:
-    release: cd
-  when: version%10 != 0 
+    convention: new
+  when: not convention
 
-# If CD release, set the respective v.r.m.f 
-# Supported CD releases as of now: 9.3.3, 9.3.4 and 9.3.5
+# If new convention, set the respective v.r.m.f 
+# Supported releases as of now: 9.3.3, 9.3.4 and 9.3.5 and 9.4 LTS
 - name: Set V.R.M.F to 9.3.3 if version matches
   ansible.builtin.set_fact:
     vrmf: '{{ vrmf933 }}'
-  when: release=='cd' and version==933
+  when: convention=='new' and version==933
 
 - name: Set V.R.M.F to 9.3.4 if version matches
   ansible.builtin.set_fact:
-    vrmf: '{{vrmf934}}'
-  when: release=='cd' and version==934
+    vrmf: '{{ vrmf934 }}'
+  when: convention=='new' and version==934
 
 - name: Set V.R.M.F to 9.3.5 if version matches
   ansible.builtin.set_fact:
-    vrmf: '{{vrmf935}}'
-  when: release=='cd' and version==935
+    vrmf: '{{ vrmf935 }}'
+  when: convention=='new' and version==935
+
+- name: Set V.R.M.F to 9.4.0 if version matches
+  ansible.builtin.set_fact:
+    vrmf: '{{ vrmf940 }}'
+  when: convention=='new' and version==940
 
 - name: Including the task list for this platform
   ansible.builtin.include_tasks: "{{ ansible_system }}_{{ ansible_architecture }}_{{ role_name }}.yml"

--- a/roles/downloadmq/tasks/main.yml
+++ b/roles/downloadmq/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Set convention type to new to other releases
   ansible.builtin.set_fact:
     convention: new
-  when: not convention
+  when: convention is undefined
 
 # If new convention, set the respective v.r.m.f 
 # Supported releases as of now: 9.3.3, 9.3.4 and 9.3.5 and 9.4 LTS

--- a/roles/downloadmq/vars/common_downloadmq.yml
+++ b/roles/downloadmq/vars/common_downloadmq.yml
@@ -3,3 +3,4 @@ downloadURL: https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/mess
 vrmf933: '9.3.3.0'
 vrmf934: '9.3.4.0'
 vrmf935: '9.3.5.0'
+vrmf940: '9.4.0.0'


### PR DESCRIPTION
9.4 zip file name now follows the new naming convention (previously only for CD releases). Therefore, naming conventions are not longer defined by type of release (LTS or CD). Instead, latest releases will have the variable `convention` as 'new'.