### PR TITLE
ARM64 download role

### DIFF
--- a/roles/downloadmq/tasks/Linux_arm64_downloadmq.yml
+++ b/roles/downloadmq/tasks/Linux_arm64_downloadmq.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set filename of zip for arm64
   ansible.builtin.set_fact:
-    zip_file: '{{ vrmf }}-IBM-MQ-Advanced-for-Developers-UbuntuLinuxARM64.tar.gz    '
+    zip_file: '{{ vrmf }}-IBM-MQ-Advanced-for-Developers-UbuntuLinuxARM64.tar.gz'
 
 
 # Get the file if local source is false


### PR DESCRIPTION
Adding in the role to download a arm64 mq dev tar.
Little bit more testing needed but in theory the install roles should be able to remain the same for Linux in general


Will require proper testing for Raspberry Pi OS -- 