### PR TITLE
Update queue_manager.py

### DIFF
--- a/plugins/modules/queue_manager.py
+++ b/plugins/modules/queue_manager.py
@@ -70,7 +70,7 @@ def run_mqsc_file(qmname, module):
                 result['msg'] = 'MQSC configuration successfully applied to queue manager.'
                 
         else:
-            rc, stdout, stderr = module.run_command(['strmqm', qmname])
+            rc, stdout, stderr = module.run_command(['strmqm', '-ns', qmname])
             rc, stdout, stderr = module.run_command(["runmqsc", qmname, "-f", module.params['mqsc_file']])
             result['rc'] = rc
             result['output'] = stdout + stderr


### PR DESCRIPTION
When temporarily starting queue manager to apply an MQSC file use the "-ns" option to avoid potential clashing with existing listeners or issuing unwanted sender channel traffic.