### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ To run the test playbooks first:
 6. if any of the tests fail, run:
 
    ```shell
-      ansible-playbook --inventory 'inventory.ini' cleanup_test.yml
+      ansible-playbook --inventory 'inventory.ini' 8_cleanup_test.yml
     ```
 
 # Ansible Galaxy - Installation


### PR DESCRIPTION
cleanup_test.yml has been replaced with 8_cleanup_test.yml to more clearly highlight the running order of the test playbooks. The readme should reflect this.